### PR TITLE
Remove elevation on step indicator

### DIFF
--- a/StepIndicator.js
+++ b/StepIndicator.js
@@ -292,8 +292,7 @@ export default class StepIndicator extends PureComponent {
     step: {
       alignItems:'center',
       justifyContent:'center',
-      zIndex: 2,
-      elevation:3
+      zIndex: 2
     },
     stepContainer: {
       flex:1,


### PR DESCRIPTION
Just fooling around with the demo and I noticed on Android the elevation has a shadow that gets cut off. This is a bit of a band-aid solution but removing it does the trick.  

With elevation:
![before](https://user-images.githubusercontent.com/5378686/27206324-c0ac2614-5204-11e7-9ba5-247ef0009439.png)

Without:
![after](https://user-images.githubusercontent.com/5378686/27206378-2ec94726-5205-11e7-8461-1a6809c58e9a.png)
