### PR TITLE
Remove PropTypes warning

### DIFF
--- a/StepIndicator.js
+++ b/StepIndicator.js
@@ -1,5 +1,6 @@
 
-import React, { PureComponent,PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types'
 import { View,Text,StyleSheet, Animated, TouchableWithoutFeedback } from 'react-native';
 
 const STEP_STATUS = {


### PR DESCRIPTION
Warning: PropTypes has been moved to a separate package. Accessing React.PropTypes is no longer supported and will be removed completely in React 16. Use the prop-types package on npm instead. (https://fb.me/migrating-from-react-proptypes)