### PR TITLE
fix proptypes import

### DIFF
--- a/StepIndicator.js
+++ b/StepIndicator.js
@@ -1,5 +1,6 @@
 
-import React, { PureComponent,PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { View,Text,StyleSheet, Animated, TouchableWithoutFeedback } from 'react-native';
 
 const STEP_STATUS = {


### PR DESCRIPTION
Latest version of react no longer supports PropTypes, need to import from prop-types.