### PR TITLE
Migrate from React.PropTypes to `prop-types` package

### DIFF
--- a/StepIndicator.js
+++ b/StepIndicator.js
@@ -1,5 +1,6 @@
 
-import React, { PureComponent,PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { View,Text,StyleSheet, Animated, TouchableWithoutFeedback } from 'react-native';
 
 const STEP_STATUS = {

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
   "bugs": {
     "url": "https://github.com/24ark/react-native-step-indicator/issues"
   },
-  "homepage": "https://github.com/24ark/react-native-step-indicator#readme"
+  "homepage": "https://github.com/24ark/react-native-step-indicator#readme",
+  "dependencies": {
+    "prop-types": "^15.6.0"
+  }
 }


### PR DESCRIPTION
React.Proptypes is deprecated in React v15.5.0
See: https://reactjs.org/blog/2017/04/07/react-v15.5.0.html