### PR TITLE
[FIX] - Number inside TouchableHighlight causes _props[registrationName] error

### DIFF
--- a/StepIndicator.js
+++ b/StepIndicator.js
@@ -232,7 +232,7 @@ export default class StepIndicator extends PureComponent {
 
       return (
         <Animated.View key={'step-indicator'} removeClippedSubviews style={[styles.step , stepStyle ]}>
-          <Text style={indicatorLabelStyle}>{ position + 1 }</Text>
+          <Text style={indicatorLabelStyle}>{ String(position + 1) }</Text>
         </Animated.View>
       );
     }


### PR DESCRIPTION
As described on this StackOverflow's question:

https://stackoverflow.com/questions/43674781/undefined-is-not-and-object-evaluating-propsregistrationname

This PR solves this problem.