### PR TITLE
Fix property 'state' in class 'StepIndicator'.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -250,4 +250,4 @@ interface StepIndicatorProps {
   onPress?(step: number): void
 }
 
-export default class StepIndicator extends React.Component<StepIndicatorProps, null> { }
+export default class StepIndicator extends React.Component<StepIndicatorProps, {}> { }


### PR DESCRIPTION
Type 'null' is not assignable to type 'Readonly<{}>' in class 'StepIndicator' then has a problem with Type Script.