### PR TITLE
Add custom style for labels alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ onPageChange(position){
 | ```labelColor``` | String  | '#000000'
 | ```currentStepLabelColor``` | String  | '#4aae4f'
 | ```labelSize``` | Number  | 13
+| ```labelAlign``` | String  | 'center'
 
 
 ### Contributing

--- a/StepIndicator.js
+++ b/StepIndicator.js
@@ -41,6 +41,7 @@ export default class StepIndicator extends PureComponent {
       stepIndicatorLabelUnFinishedColor: 'rgba(255,255,255,0.5)',
       labelColor: '#000000',
       labelSize: 13,
+      labelAlign: 'center',
       currentStepLabelColor: '#4aae4f'
     };
 
@@ -177,7 +178,10 @@ export default class StepIndicator extends PureComponent {
       });
 
       return(
-        <View style={[styles.stepLabelsContainer, direction === 'vertical' ? {flexDirection: 'column', paddingHorizontal:4} : {flexDirection: 'row', paddingVertical:4}]}>
+        <View style={[styles.stepLabelsContainer,
+          direction === 'vertical' ? {flexDirection: 'column', paddingHorizontal:4} : {flexDirection: 'row', paddingVertical:4},
+          {alignItems: this.customStyles.labelAlign}
+        ]}>
           {labelViews}
         </View>
       )
@@ -293,7 +297,6 @@ export default class StepIndicator extends PureComponent {
       backgroundColor:'transparent'
     },
     stepLabelsContainer: {
-      alignItems:'center',
       justifyContent:'space-around'
     },
     step: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -194,6 +194,16 @@ interface StepIndicatorStyles {
    * @memberof StepIndicatorStyles
    */
   labelSize?: number
+
+  /**
+   * Label alignment
+   *
+   * @default 'center
+   * @type {string}
+   * @memberof StepIndicatorStyles
+   *
+   */
+  labelAlign?: string
 }
 
 interface StepIndicatorProps {


### PR DESCRIPTION
Currently labels are always aligned in center. This seems odd, when you have indicators rendered vertically. I would want to be able to align the labels with custom style.