### PR TITLE
Change StepIndicator from PureComponent to Component

### DIFF
--- a/StepIndicator.js
+++ b/StepIndicator.js
@@ -9,7 +9,7 @@ const STEP_STATUS = {
   UNFINISHED:'unfinished'
 }
 
-export default class StepIndicator extends PureComponent {
+export default class StepIndicator extends Component {
 
   constructor(props) {
     super(props);

--- a/StepIndicator.js
+++ b/StepIndicator.js
@@ -1,5 +1,5 @@
 
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { View,Text,StyleSheet, Animated, TouchableWithoutFeedback } from 'react-native';
 


### PR DESCRIPTION
When using the new React Context API, react-native-step-indicator prevents rerendering when the context triggers a state change. This happens because `StepIndicator` indicates it is a `PureComponent` but it is not actually pure due to its use of `this.setState()` and collection objects (`PureComponent` only does a shallow compare).

This PR resolves the issue by changing StepIndicator from PureComponent to Component. After this change, rerendering works as expected.

Related issues:

- https://github.com/facebook/react/issues/13086 (When a node rerenders due to new context api update, its siblings rerender)
- https://github.com/facebook/react/issues/6515 (Children don't re-render when parent component is optimised)