### PR TITLE
Added renderStepIndicator type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -248,6 +248,17 @@ interface StepIndicatorProps {
    * @memberof StepIndicatorProps
    */
   onPress?(step: number): void
+
+   /**
+   * Used to render custom content inside step at specified position
+   * 
+   * @param {number} position 
+   * @param {string} stepStatus 
+   * 
+   * @memberof StepIndicatorProps
+   */
+  renderStepIndicator?(args: { position: number, stepStatus: string }): React.ReactNode
+
 }
 
 export default class StepIndicator extends React.Component<StepIndicatorProps, null> { }


### PR DESCRIPTION
Typescript compilation errors when using renderStepIndicator due to missing type for the prop: 

``` error TS2339: Property 'renderStepIndicator' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<StepIndicator> & Readonly<{ children?: ReactNode; ...'.```