### PR TITLE
Add finishedStepLabelColor and stepIndicatorLabelFontFamily

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -49,6 +49,8 @@ interface DefaultStepIndicatorStyles {
     | undefined;
   currentStepLabelColor: string;
   labelFontFamily?: string;
+  finishedStepLabelColor: string;
+  stepIndicatorLabelFontFamily: string;
 }
 
 const defaultStyles: DefaultStepIndicatorStyles = {
@@ -251,7 +253,9 @@ const StepIndicator = ({
     }
     var labelViews = labels.map((label, index) => {
       const selectedStepLabelStyle =
-        index === currentPosition
+        index < currentPosition
+          ? { color: customStyles.finishedStepLabelColor }
+          : index === currentPosition
           ? { color: customStyles.currentStepLabelColor }
           : { color: customStyles.labelColor };
       return (
@@ -356,6 +360,7 @@ const StepIndicator = ({
           overflow: 'hidden',
           fontSize: customStyles.stepIndicatorLabelFontSize,
           color: customStyles.stepIndicatorLabelUnFinishedColor,
+          fontFamily: customStyles.stepIndicatorLabelFontFamily,
         };
         break;
       }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -49,8 +49,8 @@ interface DefaultStepIndicatorStyles {
     | undefined;
   currentStepLabelColor: string;
   labelFontFamily?: string;
-  finishedStepLabelColor: string;
-  stepIndicatorLabelFontFamily: string;
+  finishedStepLabelColor?: string;
+  stepIndicatorLabelFontFamily?: string;
 }
 
 const defaultStyles: DefaultStepIndicatorStyles = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -205,6 +205,15 @@ export interface StepIndicatorStyles {
   currentStepLabelColor?: string;
 
   /**
+   * Color of the finished step label
+   *
+   * @default '#4aae4f'
+   * @type {string}
+   * @memberof StepIndicatorStyles
+   */
+  finishedStepLabelColor?: string;
+
+  /**
    * Font size for the labels
    *
    * @default 13
@@ -237,6 +246,15 @@ export interface StepIndicatorStyles {
    *
    */
   labelFontFamily?: string;
+
+  /**
+   * stepIndicator fontFamily for custom fonts
+   *
+   * @type {string}
+   * @memberof StepIndicatorStyles
+   *
+   */
+  stepIndicatorLabelFontFamily?: string;
 }
 
 export interface StepIndicatorProps {


### PR DESCRIPTION
This PR adds two additional props `finishedStepLabelColor` and `stepIndicatorLabelFontFamily`

`finishedStepLabelColor` provides an additional colour to apply to a label when that step is complete
`stepIndicatorLabelFontFamily` gives the ability to style the text on the steps with a custom font family (similar to `labelFontFamily`)