### PR TITLE
feat: add prop to allow switch position between indicator and label

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ onPageChange(position){
 | `currentPosition` | Number  | Current position in steps | 0
 | ```stepCount``` | Number  | Number of steps | 5
 | ```direction``` | String  | Orientation(i.e. horizontal,vertical) | horizontal
+| ```reverseLabel``` | Boolean  | Swap position between indicator and label | false
 | ```customStyles``` | Object  | Custom styling | {}
 | ```labels``` | Array  | Labels for each step | null
 | `onPress` | Function (position: Number) | Function called when a step is pressed | null

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -82,6 +82,7 @@ const StepIndicator = ({
   currentPosition = 0,
   stepCount = 5,
   direction = 'horizontal',
+  reverseLabel = false,
   customStyles: customStylesFromProps = defaultStyles,
   labels = [],
   onPress,
@@ -144,7 +145,12 @@ const StepIndicator = ({
     } else {
       progressBarBackgroundStyle = {
         ...progressBarBackgroundStyle,
-        top: (height - customStyles.separatorStrokeWidth) / 2,
+        top: reverseLabel
+          ? undefined
+          : (height - customStyles.separatorStrokeWidth) / 2,
+        bottom: reverseLabel
+          ? (height - customStyles.separatorStrokeWidth) / 2
+          : undefined,
         left: width / (2 * stepCount),
         right: width / (2 * stepCount),
         height:
@@ -187,7 +193,12 @@ const StepIndicator = ({
     } else {
       progressBarStyle = {
         ...progressBarStyle,
-        top: (height - customStyles.separatorStrokeWidth) / 2,
+        top: reverseLabel
+          ? undefined
+          : (height - customStyles.separatorStrokeWidth) / 2,
+        bottom: reverseLabel
+          ? (height - customStyles.separatorStrokeWidth) / 2
+          : undefined,
         left: width / (2 * stepCount),
         right: width / (2 * stepCount),
         height:
@@ -420,8 +431,8 @@ const StepIndicator = ({
       style={[
         styles.container,
         direction === 'vertical'
-          ? { flexDirection: 'row', flex: 1 }
-          : { flexDirection: 'column' },
+          ? { flexDirection: reverseLabel ? 'row-reverse' : 'row', flex: 1 }
+          : { flexDirection: reverseLabel ? 'column-reverse' : 'column' },
       ]}
     >
       {width !== 0 && (

--- a/src/types.ts
+++ b/src/types.ts
@@ -268,6 +268,15 @@ export interface StepIndicatorProps {
   direction?: 'horizontal' | 'vertical';
 
   /**
+   * Reverse label and indicator
+   *
+   * @default false
+   * @type {boolean}
+   * @memberof StepIndicatorProps
+   */
+  reverseLabel?: boolean;
+
+  /**
    * Styles for the component
    *
    * @type {StepIndicatorStyles}


### PR DESCRIPTION
based on the issue https://github.com/24ark/react-native-step-indicator/issues/103, and the recommend way to do from the owner.

I made a small pr to update it 

<img width="366" alt="Screenshot_2020_09_11_20_44" src="https://user-images.githubusercontent.com/30365498/92921768-a54c2700-f46f-11ea-9af1-b0a34c4ee841.png">
<img width="373" alt="Screenshot_2020_09_11_20_45" src="https://user-images.githubusercontent.com/30365498/92921806-b39a4300-f46f-11ea-87fa-5f2b0aa5d0a9.png">
<img width="381" alt="Screenshot_2020_09_11_20_49" src="https://user-images.githubusercontent.com/30365498/92922166-55219480-f470-11ea-8810-0483bf274adb.png">
<img width="375" alt="Screenshot_2020_09_11_20_50" src="https://user-images.githubusercontent.com/30365498/92922199-65d20a80-f470-11ea-86c8-cdd3f168510f.png">


